### PR TITLE
chore: remove unnecessary duplicate array

### DIFF
--- a/src/Provider.php
+++ b/src/Provider.php
@@ -54,14 +54,6 @@ class Provider extends AbstractProvider
         ]);
     }
 
-    /** {@inheritdoc} */
-    protected function getTokenFields($code)
-    {
-        return array_merge(parent::getTokenFields($code), [
-            'grant_type' => 'authorization_code',
-        ]);
-    }
-
     protected function getUri(string $path = ''): string
     {
         return $this->getConfig('auth_uri', static::URL).$path;


### PR DESCRIPTION
The selected `grant_types` is already the default in Socialite, so no need to specify it again. 👍🏻